### PR TITLE
Bug: Fix GitHub Auth

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
       - checkout
       - run:
           name: Package and Cut Release
-          command: make release
+          command: BUILD_NUM=$CIRCLE_BUILD_NUM make release
 
 workflows:
   version: 2


### PR DESCRIPTION
The token will now be formatted as:
```
github_username:personal_token
```

Previously, the token was just passed as a get param without the username.

- Fix authentication to GH API
- Update CI releases
- Cleanup